### PR TITLE
Proposal: add mindhunter

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -29,3 +29,7 @@
 - url: https://github.com/a-chacon/oas_rails
   domain: [api, documentation]
   lang: ruby
+
+- url: https://github.com/Framebuffers/mindhunter
+  domain: [data, statistics]
+  lang: python


### PR DESCRIPTION
Mindhunter is a wrapper for pandas DataFrames. It adds extra functionality for them to do statistical analysis much easier. 